### PR TITLE
[PR2777] Remove warnings (gcc/clang)

### DIFF
--- a/Sofa/Component/Diffusion/src/sofa/component/diffusion/TetrahedronDiffusionFEMForceField.h
+++ b/Sofa/Component/Diffusion/src/sofa/component/diffusion/TetrahedronDiffusionFEMForceField.h
@@ -76,7 +76,7 @@ public:
       void addKToMatrix(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
 
       void buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix) override;
-      void buildDampingMatrix(core::behavior::DampingMatrix* matrices) override {}
+      void buildDampingMatrix(core::behavior::DampingMatrix* /* matrices */) override {}
 
       /// Return Potential energy of the mesh.
       SReal getPotentialEnergy(const core::MechanicalParams* /*mparams*/, const DataVecCoord& x) const override;

--- a/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSystem[GraphScattered].cpp
+++ b/Sofa/Component/LinearSolver/Iterative/src/sofa/component/linearsolver/iterative/MatrixLinearSystem[GraphScattered].cpp
@@ -58,11 +58,15 @@ void TypedMatrixLinearSystem<GraphScatteredMatrix, GraphScatteredVector>::copyLo
 
 template<> SOFA_COMPONENT_LINEARSOLVER_ITERATIVE_API
 void TypedMatrixLinearSystem<GraphScatteredMatrix, GraphScatteredVector>::dispatchSystemSolution(core::MultiVecDerivId v)
-{}
+{
+    SOFA_UNUSED(v);
+}
 
 template<> SOFA_COMPONENT_LINEARSOLVER_ITERATIVE_API
 void TypedMatrixLinearSystem<GraphScatteredMatrix, GraphScatteredVector>::dispatchSystemRHS(core::MultiVecDerivId v)
-{}
+{
+    SOFA_UNUSED(v);
+}
 
 template class SOFA_COMPONENT_LINEARSOLVER_ITERATIVE_API TypedMatrixLinearSystem< GraphScatteredMatrix, GraphScatteredVector >;
 

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MappingGraph.cpp
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MappingGraph.cpp
@@ -266,6 +266,8 @@ bool MappingGraph::isBuilt() const
 
 void MappingGraph::build(const sofa::core::ExecParams* params, core::objectmodel::BaseContext* rootNode)
 {
+    SOFA_UNUSED(params);
+
     m_rootNode = rootNode;
 
     m_mainMechanicalStates.clear();

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixFreeSystem.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixFreeSystem.h
@@ -33,8 +33,8 @@ class SOFA_COMPONENT_LINEARSYSTEM_API MatrixFreeSystem : public TypedMatrixLinea
 public:
     SOFA_CLASS(SOFA_TEMPLATE2(MatrixFreeSystem, TMatrix, TVector), SOFA_TEMPLATE2(TypedMatrixLinearSystem, TMatrix, TVector));
 
-    void assembleSystem(const core::MechanicalParams* mparams) override {}
-    void associateLocalMatrixToComponents(const core::MechanicalParams* mparams) override {}
+    void assembleSystem(const core::MechanicalParams* /* mparams */) override {}
+    void associateLocalMatrixToComponents(const core::MechanicalParams* /* mparams */) override {}
 };
 
 } //namespace sofa::component::linearsystem

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.inl
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/MatrixLinearSystem.inl
@@ -300,6 +300,8 @@ void MatrixLinearSystem<TMatrix, TVector>::buildGroupsOfComponentAssociatedToMec
 template <class TMatrix, class TVector>
 void MatrixLinearSystem<TMatrix, TVector>::makeLocalMatrixGroups(const core::MechanicalParams* mparams)
 {
+    SOFA_UNUSED(mparams);
+
     m_localMappedMatrices.clear();
 
     std::map<PairMechanicalStates, GroupOfComponentsAssociatedToAPairOfMechanicalStates> groups;

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/matrixaccumulators/BaseAssemblingMatrixAccumulator.h
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/matrixaccumulators/BaseAssemblingMatrixAccumulator.h
@@ -46,7 +46,7 @@ public:
     [[nodiscard]]
     type::Vec<2, unsigned> getPositionInGlobalMatrix() const;
 
-    void addContributionsToMatrix(sofa::linearalgebra::BaseMatrix* globalMatrix, SReal factor, const sofa::type::Vec2u& positionInMatrix) {}
+    void addContributionsToMatrix(sofa::linearalgebra::BaseMatrix* /* globalMatrix */, SReal /* factor */, const sofa::type::Vec2u& /* positionInMatrix */) {}
 
 protected:
 

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/visitors/AssembleGlobalVectorFromLocalVectorVisitor.cpp
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/visitors/AssembleGlobalVectorFromLocalVectorVisitor.cpp
@@ -36,6 +36,8 @@ AssembleGlobalVectorFromLocalVectorVisitor::AssembleGlobalVectorFromLocalVectorV
 simulation::Visitor::Result AssembleGlobalVectorFromLocalVectorVisitor::fwdMechanicalState(simulation::Node* node,
                                                                                            core::behavior::BaseMechanicalState* mm)
 {
+    SOFA_UNUSED(node);
+
     if (mm)
     {
         auto pos = m_mappingGraph.getPositionInGlobalMatrix(mm);

--- a/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/visitors/DispatchFromGlobalVectorToLocalVectorVisitor.cpp
+++ b/Sofa/Component/LinearSystem/src/sofa/component/linearsystem/visitors/DispatchFromGlobalVectorToLocalVectorVisitor.cpp
@@ -36,6 +36,8 @@ DispatchFromGlobalVectorToLocalVectorVisitor::DispatchFromGlobalVectorToLocalVec
 simulation::Visitor::Result DispatchFromGlobalVectorToLocalVectorVisitor::fwdMechanicalState(simulation::Node* node,
                                                                                            core::behavior::BaseMechanicalState* mm)
 {
+    SOFA_UNUSED(node);
+
     if (mm)
     {
         auto pos = m_mappingGraph.getPositionInGlobalMatrix(mm);

--- a/Sofa/Component/Mapping/MappedMatrix/src/sofa/component/mapping/mappedmatrix/MechanicalMatrixMapper.h
+++ b/Sofa/Component/Mapping/MappedMatrix/src/sofa/component/mapping/mappedmatrix/MechanicalMatrixMapper.h
@@ -22,7 +22,10 @@
 #pragma once
 
 #include <sofa/component/mapping/mappedmatrix/config.h>
+
+#ifndef SOFA_BUILD_SOFA_COMPONENT_MAPPING_MAPPEDMATRIX
 SOFA_DEPRECATED_HEADER_NOT_REPLACED("v23.06", "v23.12")
+#endif
 
 #include <sofa/core/behavior/MixedInteractionForceField.h>
 #include <sofa/core/behavior/MechanicalState.h>

--- a/Sofa/Component/Mapping/MappedMatrix/src/sofa/component/mapping/mappedmatrix/MechanicalMatrixMapper.inl
+++ b/Sofa/Component/Mapping/MappedMatrix/src/sofa/component/mapping/mappedmatrix/MechanicalMatrixMapper.inl
@@ -22,7 +22,9 @@
 #pragma once
 
 #include <sofa/component/mapping/mappedmatrix/MechanicalMatrixMapper.h>
+#ifndef SOFA_BUILD_SOFA_COMPONENT_MAPPING_MAPPEDMATRIX
 SOFA_DEPRECATED_HEADER_NOT_REPLACED("v23.06", "v23.12")
+#endif
 
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/rmath.h>

--- a/Sofa/Component/Mass/src/sofa/component/mass/DiagonalMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/DiagonalMass.h
@@ -316,8 +316,8 @@ public:
     /// Add Mass contribution to global Matrix assembling
     void addMToMatrix(const core::MechanicalParams *mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
     void buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices) override;
-    void buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix) override {}
-    void buildDampingMatrix(core::behavior::DampingMatrix* matrices) override {}
+    void buildStiffnessMatrix(core::behavior::StiffnessMatrix* /* matrix */) override {}
+    void buildDampingMatrix(core::behavior::DampingMatrix* /* matrices */) override {}
 
     SReal getElementMass(sofa::Index index) const override;
     void getElementMass(sofa::Index, linearalgebra::BaseMatrix *m) const override;

--- a/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/MeshMatrixMass.h
@@ -221,8 +221,8 @@ public:
     /// Add Mass contribution to global Matrix assembling
     void addMToMatrix(const core::MechanicalParams *mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
     void buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices) override;
-    void buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix) override {}
-    void buildDampingMatrix(core::behavior::DampingMatrix* matrices) override {}
+    void buildStiffnessMatrix(core::behavior::StiffnessMatrix* /* matrix */) override {}
+    void buildDampingMatrix(core::behavior::DampingMatrix* /* matrices */) override {}
 
     SReal getElementMass(Index index) const override;
     void getElementMass(Index index, linearalgebra::BaseMatrix *m) const override;

--- a/Sofa/Component/Mass/src/sofa/component/mass/UniformMass.h
+++ b/Sofa/Component/Mass/src/sofa/component/mass/UniformMass.h
@@ -144,8 +144,8 @@ public:
 
     void addMToMatrix(const core::MechanicalParams *mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override; /// Add Mass contribution to global Matrix assembling
     void buildMassMatrix(sofa::core::behavior::MassMatrixAccumulator* matrices) override;
-    void buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix) override {}
-    void buildDampingMatrix(core::behavior::DampingMatrix* matrices) override {}
+    void buildStiffnessMatrix(core::behavior::StiffnessMatrix* /* matrix */) override {}
+    void buildDampingMatrix(core::behavior::DampingMatrix* /* matrices */) override {}
 
     SReal getElementMass(sofa::Index index) const override;
     void getElementMass(sofa::Index index, linearalgebra::BaseMatrix *m) const override;

--- a/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.h
+++ b/Sofa/Component/SolidMechanics/FEM/Elastic/src/sofa/component/solidmechanics/fem/elastic/HexahedronFEMForceField.h
@@ -156,7 +156,7 @@ public:
 
     void addKToMatrix(const core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
     void buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix) override;
-    void buildDampingMatrix(core::behavior::DampingMatrix* matrices) override {}
+    void buildDampingMatrix(core::behavior::DampingMatrix* /* matrices */) override {}
 
     void computeBBox(const core::ExecParams* params, bool onlyVisible) override;
 

--- a/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/StiffSpringForceField.h
+++ b/Sofa/Component/SolidMechanics/Spring/src/sofa/component/solidmechanics/spring/StiffSpringForceField.h
@@ -101,7 +101,7 @@ public:
     using Inherit::addKToMatrix;
     void addKToMatrix(const sofa::core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* matrix) override;
     void buildStiffnessMatrix(core::behavior::StiffnessMatrix* matrix) override;
-    void buildDampingMatrix(core::behavior::DampingMatrix* matrices) override {}
+    void buildDampingMatrix(core::behavior::DampingMatrix* /* matrices */) override {}
 
 
 protected:

--- a/Sofa/framework/Core/src/sofa/core/BaseMapping.cpp
+++ b/Sofa/framework/Core/src/sofa/core/BaseMapping.cpp
@@ -141,6 +141,7 @@ sofa::linearalgebra::BaseMatrix* BaseMapping::createMappedMatrix(const behavior:
 
 void BaseMapping::buildGeometricStiffnessMatrix(sofa::core::GeometricStiffnessMatrix* matrices)
 {
+    SOFA_UNUSED(matrices);
 }
 
 bool BaseMapping::testMechanicalState(BaseState* state)

--- a/Sofa/framework/Core/src/sofa/core/MatrixAccumulator.h
+++ b/Sofa/framework/Core/src/sofa/core/MatrixAccumulator.h
@@ -82,8 +82,8 @@ struct SOFA_CORE_API NoIndexVerification : IndexVerificationStrategy
 {
     using verify_index = std::false_type;
 private:
-    void checkRowIndex(sofa::SignedIndex row) override {}
-    void checkColIndex(sofa::SignedIndex col) override {}
+    void checkRowIndex(sofa::SignedIndex /* row */) override {}
+    void checkColIndex(sofa::SignedIndex /* col */) override {}
 };
 
 struct SOFA_CORE_API RangeVerification : IndexVerificationStrategy
@@ -257,7 +257,7 @@ public:
         return m_list.empty();
     }
 
-    void clear()
+    void clear() override
     {
         for (auto* mat : m_list)
         {

--- a/Sofa/framework/Core/src/sofa/core/MatrixAccumulator.h
+++ b/Sofa/framework/Core/src/sofa/core/MatrixAccumulator.h
@@ -203,6 +203,8 @@ public:
 
 protected:
 
+    using TBaseMatrixAccumulator::add;
+
     virtual void add(const matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, float value)
     {
         TBaseMatrixAccumulator::add(row, col, value);
@@ -211,7 +213,6 @@ protected:
     {
         TBaseMatrixAccumulator::add(row, col, value);
     }
-
     virtual void add(const matrixaccumulator::no_check_policy&, sofa::SignedIndex row, sofa::SignedIndex col, const sofa::type::Mat<3, 3, float>& value)
     {
         TBaseMatrixAccumulator::add(row, col, value);

--- a/Sofa/framework/Core/src/sofa/core/behavior/BaseMatrixLinearSystem.cpp
+++ b/Sofa/framework/Core/src/sofa/core/behavior/BaseMatrixLinearSystem.cpp
@@ -39,9 +39,13 @@ void BaseMatrixLinearSystem::buildSystemMatrix(const core::MechanicalParams* mpa
 }
 
 void BaseMatrixLinearSystem::preAssembleSystem(const core::MechanicalParams* mparams)
-{}
+{
+    SOFA_UNUSED(mparams);
+}
 
-void BaseMatrixLinearSystem::assembleSystem(const core::MechanicalParams* /*mparams*/)
-{}
+void BaseMatrixLinearSystem::assembleSystem(const core::MechanicalParams* mparams)
+{
+    SOFA_UNUSED(mparams);
+}
 
 } //namespace sofa::core::behavior

--- a/Sofa/framework/Core/src/sofa/core/behavior/MatrixAPICompatibility.h
+++ b/Sofa/framework/Core/src/sofa/core/behavior/MatrixAPICompatibility.h
@@ -87,11 +87,17 @@ public:
     }
     SReal element(Index i, Index j) const override
     {
+        SOFA_UNUSED(i);
+        SOFA_UNUSED(j);
+
         msg_error(component) << compatibilityMessage << "element is not a supported operation in the compatibility";
         return {};
     }
     void resize(Index nbRow, Index nbCol) override
     {
+        SOFA_UNUSED(nbRow);
+        SOFA_UNUSED(nbCol);
+
         msg_error(component) << compatibilityMessage << "resize is not a supported operation in the compatibility";
     }
     void clear() override
@@ -100,6 +106,10 @@ public:
     }
     void set(Index i, Index j, double v) override
     {
+        SOFA_UNUSED(i);
+        SOFA_UNUSED(j);
+        SOFA_UNUSED(v);
+
         msg_error(component) << compatibilityMessage << "set is not a supported operation in the compatibility";
     }
     void add(Index row, Index col, double v) override
@@ -182,11 +192,17 @@ public:
     }
     SReal element(Index i, Index j) const override
     {
+        SOFA_UNUSED(i);
+        SOFA_UNUSED(j);
+
         msg_error(component) << compatibilityMessage << "element is not a supported operation in the compatibility";
         return {};
     }
     void resize(Index nbRow, Index nbCol) override
     {
+        SOFA_UNUSED(nbRow);
+        SOFA_UNUSED(nbCol);
+
         msg_error(component) << compatibilityMessage << "resize is not a supported operation in the compatibility";
     }
     void clear() override
@@ -195,10 +211,16 @@ public:
     }
     void set(Index i, Index j, double v) override
     {
-
+        SOFA_UNUSED(i);
+        SOFA_UNUSED(j);
+        SOFA_UNUSED(v);
     }
     void add(Index row, Index col, double v) override
     {
+        SOFA_UNUSED(row);
+        SOFA_UNUSED(col);
+        SOFA_UNUSED(v);
+
         msg_error(component) << compatibilityMessage << "add is not a supported operation in the compatibility";
     }
 

--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalIdentityBlocksInJacobianVisitor.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/mechanicalvisitor/MechanicalIdentityBlocksInJacobianVisitor.cpp
@@ -35,9 +35,10 @@ MechanicalIdentityBlocksInJacobianVisitor::MechanicalIdentityBlocksInJacobianVis
 {
 }
 
-Visitor::Result MechanicalIdentityBlocksInJacobianVisitor::fwdMechanicalMapping(simulation::Node* /*node*/,
+Visitor::Result MechanicalIdentityBlocksInJacobianVisitor::fwdMechanicalMapping(simulation::Node* node,
     sofa::core::BaseMapping* map)
 {
+    SOFA_UNUSED(node);
     const auto parents = map->getMechFrom();
 
     //insert mechanical states which have children
@@ -49,6 +50,7 @@ Visitor::Result MechanicalIdentityBlocksInJacobianVisitor::fwdMechanicalMapping(
 void MechanicalIdentityBlocksInJacobianVisitor::bwdMappedMechanicalState(simulation::Node* node,
     sofa::core::behavior::BaseMechanicalState* mm)
 {
+    SOFA_UNUSED(node);
     if (listParentMStates.find(mm) == listParentMStates.end())
     {
         //this mechanical state does not have any children
@@ -63,6 +65,9 @@ void MechanicalIdentityBlocksInJacobianVisitor::bwdMappedMechanicalState(simulat
 bool MechanicalIdentityBlocksInJacobianVisitor::stopAtMechanicalMapping(simulation::Node* node,
     core::BaseMapping* base_mapping)
 {
+    SOFA_UNUSED(node);
+    SOFA_UNUSED(base_mapping);
+
     return false;
 }
 } //namespace sofa::simulation::mechanicalvisitor


### PR DESCRIPTION
Just a quick pass on gcc/clang.
remove warnings about : override, not used warnings and hidden overloads

removing repetitive getValues() in MatrixLinearSolver (because I just happen to see it...)


______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
