### PR TITLE
[Node] Fix in findLinkDestClass

### DIFF
--- a/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
+++ b/Sofa/framework/Simulation/Core/src/sofa/simulation/Node.cpp
@@ -460,6 +460,11 @@ sofa::core::objectmodel::Base* Node::findLinkDestClass(const core::objectmodel::
             return destType->dynamicCast(this->getVisualLoop());
     }
 
+    if (decomposition.empty())
+    {
+        return destType->dynamicCast(this);
+    }
+    
     const auto& firstElement = decomposition.front();
 
     if (firstElement == "..")


### PR DESCRIPTION
Hello !

This is a fix in findLinkDestClass in order to manage the case "@./" links.

______________________________________________________

By submitting this pull request, I acknowledge that  
**I have read, understand, and agree [SOFA Developer Certificate of Origin (DCO)](https://github.com/sofa-framework/sofa/blob/master/CONTRIBUTING.md#sofa-developer-certificate-of-origin-dco)**.
______________________________________________________

**Reviewers will merge this pull-request only if**  
- it builds with SUCCESS for all platforms on the CI.
- it does not generate new warnings.
- it does not generate new unit test failures.
- it does not generate new scene test failures.
- it does not break API compatibility.
- it is more than 1 week old (or has fast-merge label).
